### PR TITLE
Feature: enable ignoring query string

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,8 +14,9 @@ sphinx = "*"
 sphinx-rtd-theme = "*"
 tox = "*"
 isort = "*"
-pytest-black = "*"
 twine = "*"
+black = "*"
+pytest-black = "*"
 
 [packages]
 django = "*"
@@ -25,3 +26,6 @@ django-inline-static = "*"
 
 [requires]
 python_version = "3.7"
+
+[pipenv]
+allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -24,4 +24,4 @@ django-rq = "*"
 django-inline-static = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/critical/api.py
+++ b/critical/api.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from .exceptions import PenthouseException
 from .utils import complete_url
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/critical/apps.py
+++ b/critical/apps.py
@@ -11,6 +11,7 @@ class CriticalConfig(AppConfig):
             # If django-cms is installed include signals
             # for refreshing critical css on page publish
             import cms  # noqa
+
             import critical.signals.handlers  # noqa
         except ImportError:
             pass

--- a/critical/signals/handlers.py
+++ b/critical/signals/handlers.py
@@ -5,7 +5,6 @@ from django.dispatch import receiver
 
 from ..models import Critical
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/critical/tasks.py
+++ b/critical/tasks.py
@@ -11,8 +11,7 @@ logger = logging.getLogger(__name__)
 def calculate_critical_css(critical_id, original_path):
     from .exceptions import CriticalException
     from .models import Critical
-    from .services import \
-        calculate_critical_css as service_calculate_critical_css
+    from .services import calculate_critical_css as service_calculate
 
     logger.info('Task: critical css with id {0} requested.'.format(critical_id))
     critical = Critical.objects.filter(id=critical_id).first()
@@ -25,7 +24,7 @@ def calculate_critical_css(critical_id, original_path):
     logger.info('Task: critical css with id {0} pending.'.format(critical_id))
 
     try:
-        critical_css_raw = service_calculate_critical_css(critical.url, critical.path)
+        critical_css_raw = service_calculate(critical.url, critical.path)
         critical_css = transform_css_urls(original_path, critical.path, critical_css_raw)
     except Exception as exc:
         critical.is_pending = False

--- a/critical/tasks.py
+++ b/critical/tasks.py
@@ -4,15 +4,15 @@ from django.utils.safestring import mark_safe
 from django_rq import job
 from inline_static.css import transform_css_urls
 
-
 logger = logging.getLogger(__name__)
 
 
 @job
 def calculate_critical_css(critical_id, original_path):
-    from .services import calculate_critical_css as service_calculate_critical_css
     from .exceptions import CriticalException
     from .models import Critical
+    from .services import \
+        calculate_critical_css as service_calculate_critical_css
 
     logger.info('Task: critical css with id {0} requested.'.format(critical_id))
     critical = Critical.objects.filter(id=critical_id).first()

--- a/critical/templatetags/critical_tags.py
+++ b/critical/templatetags/critical_tags.py
@@ -7,7 +7,6 @@ from ..models import Critical
 from ..tasks import calculate_critical_css
 from ..utils import get_url_from_request, use_critical_css_for_request
 
-
 register = template.Library()
 logger = logging.getLogger(__name__)
 

--- a/critical/utils.py
+++ b/critical/utils.py
@@ -28,6 +28,8 @@ def get_url_from_request(request):
         Page ansolute url.
 
     """
+    if getattr(settings, 'CRITICAL_CSS_IGNORE_QUERY_STRING', False):
+        return request.path
     return request.get_full_path()
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -91,7 +91,9 @@ Additional settings
 
 * By setting ``CRITICAL_CSS_ACTIVE`` to `False` you can deactivate css calculation
   for your dev environment. By default critical css calculation is set to active.
-
+* By setting ``CRITICAL_CSS_IGNORE_QUERY_STRING`` to `False` you can ignore query string
+  in the url. Then both urls `/?p=1`and `/?p=2` will be treated as one `/` and only one database
+  object will be created.
 
 Usage with django-cms
 ---------------------

--- a/examples/critical-example/criticalexample/settings.py
+++ b/examples/critical-example/criticalexample/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 
 import os
 
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/examples/critical-example/criticalexample/urls.py
+++ b/examples/critical-example/criticalexample/urls.py
@@ -18,7 +18,6 @@ from django.urls import include, path
 
 from .views import ExampleView
 
-
 urlpatterns = [
     path('admin/rq/', include('django_rq.urls')),
     path('admin/', admin.site.urls),

--- a/examples/critical-example/criticalexample/wsgi.py
+++ b/examples/critical-example/criticalexample/wsgi.py
@@ -11,7 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'criticalexample.settings')
 
 application = get_wsgi_application()

--- a/examples/critical-example/manage.py
+++ b/examples/critical-example/manage.py
@@ -2,7 +2,6 @@
 import os
 import sys
 
-
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'criticalexample.settings')
     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,9 @@ python_files =
 
 cov_report = term-missing
 
+markers =
+	cms: marks tests that require django-cms
+
 
 DJANGO_SETTINGS_MODULE = tests.settings
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tests/cms_settings.py
+++ b/tests/cms_settings.py
@@ -1,6 +1,5 @@
 import os
 
-
 LANGUAGE_CODE = 'de'
 
 ROOT_URLCONF = 'tests.urls'

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,7 +3,7 @@ import factory
 from critical.models import Critical
 
 
-class CriticalFactory(factory.DjangoModelFactory):
+class CriticalFactory(factory.django.DjangoModelFactory):
     url = factory.Faker('url')
     path = factory.Faker('uri_path')
     css = factory.Faker('text')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -26,6 +26,7 @@ RQ_QUEUES = {'default': {'HOST': 'localhost', 'PORT': 6379, 'DB': 0, 'ASYNC': Fa
 
 CRITICAL_CSS_ACTIVE = True
 PENTHOUSE_URL = 'http://localhost:3000/'
+CRITICAL_CSS_IGNORE_QUERY_STRING = False
 
 try:
     import cms  # noqa

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,11 @@ import pytest
 import requests
 from django.contrib.sites.models import Site
 
-from critical.api import PenthouseApi, PenthouseException, calculate_critical_css
+from critical.api import (
+    PenthouseApi,
+    PenthouseException,
+    calculate_critical_css,
+)
 
 
 @pytest.mark.django_db

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -2,7 +2,6 @@ import pytest
 
 from critical.models import Critical
 
-
 try:
     from cms.api import create_page, publish_page
 except ImportError:

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -56,7 +56,8 @@ class TestCriticalTags:
     @mock.patch('critical.templatetags.critical_tags.calculate_critical_css')
     @mock.patch('critical.templatetags.critical_tags.use_critical_css_for_request')
     def test_critical_object_created_with_query_string(
-            self, use_critical_mock, critical_task_mock, rf, settings):
+        self, use_critical_mock, critical_task_mock, rf, settings
+    ):
         settings.CRITICAL_CSS_IGNORE_QUERY_STRING = False
         use_critical_mock.return_value = True
         critical_task_mock.delay.return_value = 'foo bar bazz'
@@ -82,7 +83,8 @@ class TestCriticalTags:
     @mock.patch('critical.templatetags.critical_tags.calculate_critical_css')
     @mock.patch('critical.templatetags.critical_tags.use_critical_css_for_request')
     def test_critical_object_created_ignore_query_string(
-            self, use_critical_mock, critical_task_mock, rf, settings):
+        self, use_critical_mock, critical_task_mock, rf, settings
+    ):
         settings.CRITICAL_CSS_IGNORE_QUERY_STRING = True
 
         request = rf.get('/?p=1')
@@ -122,7 +124,8 @@ class TestCriticalTags:
     @mock.patch('critical.templatetags.critical_tags.calculate_critical_css')
     @mock.patch('critical.templatetags.critical_tags.use_critical_css_for_request')
     def test_success_ignore_query_string(
-            self, use_critical_mock, critical_task_mock, rf, settings):
+        self, use_critical_mock, critical_task_mock, rf, settings
+    ):
         settings.CRITICAL_CSS_IGNORE_QUERY_STRING = True
         use_critical_mock.return_value = True
         request = rf.get('/?p=3')

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -55,9 +55,77 @@ class TestCriticalTags:
 
     @mock.patch('critical.templatetags.critical_tags.calculate_critical_css')
     @mock.patch('critical.templatetags.critical_tags.use_critical_css_for_request')
+    def test_critical_object_created_with_query_string(
+            self, use_critical_mock, critical_task_mock, rf, settings):
+        settings.CRITICAL_CSS_IGNORE_QUERY_STRING = False
+        use_critical_mock.return_value = True
+        critical_task_mock.delay.return_value = 'foo bar bazz'
+
+        request = rf.get('/?p=1')
+        context = Context({'request': request})
+        template_to_render = Template(
+            '{% load critical_tags %}' '{% critical_css "css/styles.css" %}'
+        )
+        template_to_render.render(context)
+
+        request = rf.get('/?p=2')
+        context = Context({'request': request})
+        template_to_render = Template(
+            '{% load critical_tags %}' '{% critical_css "css/styles.css" %}'
+        )
+        template_to_render.render(context)
+
+        assert Critical.objects.filter(url='/').count() == 0
+        assert Critical.objects.filter(url='/?p=1').count() == 1
+        assert Critical.objects.filter(url='/?p=2').count() == 1
+
+    @mock.patch('critical.templatetags.critical_tags.calculate_critical_css')
+    @mock.patch('critical.templatetags.critical_tags.use_critical_css_for_request')
+    def test_critical_object_created_ignore_query_string(
+            self, use_critical_mock, critical_task_mock, rf, settings):
+        settings.CRITICAL_CSS_IGNORE_QUERY_STRING = True
+
+        request = rf.get('/?p=1')
+        context = Context({'request': request})
+        template_to_render = Template(
+            '{% load critical_tags %}' '{% critical_css "css/styles.css" %}'
+        )
+        template_to_render.render(context)
+
+        request = rf.get('/?p=2')
+        context = Context({'request': request})
+        template_to_render = Template(
+            '{% load critical_tags %}' '{% critical_css "css/styles.css" %}'
+        )
+        template_to_render.render(context)
+
+        assert Critical.objects.filter(url='/').count() == 1
+        assert Critical.objects.filter(url='/?p=1').count() == 0
+        assert Critical.objects.filter(url='/?p=2').count() == 0
+
+    @mock.patch('critical.templatetags.critical_tags.calculate_critical_css')
+    @mock.patch('critical.templatetags.critical_tags.use_critical_css_for_request')
     def test_success(self, use_critical_mock, critical_task_mock, rf):
         use_critical_mock.return_value = True
         request = rf.get('/')
+        CriticalFactory.create(url='/', path='/static/css/styles.css', css='foo bar')
+
+        context = Context({'request': request})
+        template_to_render = Template(
+            '{% load critical_tags %}' '{% critical_css "css/styles.css" %}'
+        )
+
+        rendered_template = template_to_render.render(context)
+        assert '<style type="text/css">foo bar</style>' in rendered_template
+        assert critical_task_mock.delay.call_count == 0
+
+    @mock.patch('critical.templatetags.critical_tags.calculate_critical_css')
+    @mock.patch('critical.templatetags.critical_tags.use_critical_css_for_request')
+    def test_success_ignore_query_string(
+            self, use_critical_mock, critical_task_mock, rf, settings):
+        settings.CRITICAL_CSS_IGNORE_QUERY_STRING = True
+        use_critical_mock.return_value = True
+        request = rf.get('/?p=3')
         CriticalFactory.create(url='/', path='/static/css/styles.css', css='foo bar')
 
         context = Context({'request': request})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,6 @@ from critical.utils import (
     use_critical_css_for_request,
 )
 
-
 try:
     from cms.api import create_page, publish_page
     from cms.models import Page

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,9 @@ def test_django_cms_is_present():
         assert django_cms_is_present() is False
 
 
-def test_get_url_from_request(rf):
+def test_get_url_from_request(rf, settings):
+    settings.CRITICAL_CSS_IGNORE_QUERY_STRING = False
+
     request = rf.get('/')
     assert get_url_from_request(request) == '/'
 
@@ -36,6 +38,11 @@ def test_get_url_from_request(rf):
 
     request = rf.get('/#anchor')
     assert get_url_from_request(request) == '/'
+
+    settings.CRITICAL_CSS_IGNORE_QUERY_STRING = True
+
+    request = rf.get('/foo/?bar=bazz')
+    assert get_url_from_request(request) == '/foo/'
 
 
 @mock.patch('critical.utils.Site.objects.get_current')

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,13 @@
 [tox]
 skipsdist = True
 envlist=
-	py36-django111
-	py36-django22
-	py36-django111-djangocms36
-	py36-django22-djangocms36
+	py37-django22
+	py37-django22-djangocms36
 
 [testenv]
 whitelist_externals = /bin/sh
 deps =
 	pipenv
-	django111: Django>=1.11,<1.12
 	django22: Django>=2.2,<2.3
 	djangocms36: django-cms>=3.6,<3.7
 


### PR DESCRIPTION
Add setting that enables ignoring query string sothat Critical css will be calculated just for the main url.